### PR TITLE
Fix small issues when switch to Python 3

### DIFF
--- a/osrframework/searchengines/__init__.py
+++ b/osrframework/searchengines/__init__.py
@@ -17,7 +17,3 @@
 #
 ##################################################################################
 
-import osrframework.utils.logger as logger
-
-# Calling the logger when being imported
-logger.setupLogger(loggerName="osrframework.searchengines")

--- a/osrframework/thirdparties/pipl_com/lib/__init__.py
+++ b/osrframework/thirdparties/pipl_com/lib/__init__.py
@@ -20,11 +20,6 @@
 ##################################################################################
 
 
-import osrframework.utils.logger
-
-# Calling the logger when being imported
-osrframework.utils.logger.setupLogger(loggerName="osrframework.thirdparties.pipl_com.lib")
-
 
 __version__ = '1.0'
 """Python implementation of Pipl's data model.

--- a/osrframework/utils/exceptions.py
+++ b/osrframework/utils/exceptions.py
@@ -47,7 +47,7 @@ class NoCredentialsException(OSRFrameworkException):
             """.format(
             self.__class__.__name__,
             platform,
-            os.path.join(configuration.getConfigPath()["appPath"], "accounts.cfg"),
+            os.path.join(configuration.get_config_path()["appPath"], "accounts.cfg"),
             general.emphasis("-x " + platform)
         )
         OSRFrameworkException.__init__(self, general.warning(msg))


### PR DESCRIPTION
Hello,

I noticed small errors:
- osrframework/utils/logger.py but it's still imported in 2 files
- you rename getConfigPath to get_config_path but old name still used in osrframework/utils/exceptions.py