### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-bs4
+beautifulsoup4
 requests
 python-emailahoy3
 pyexcel==0.2.1


### PR DESCRIPTION
`bs4` is a dummy package which points to `beautifulsoup4`. Distributions don't have `bs4` in a lot of cases.